### PR TITLE
fix: add white background to chat panel containers

### DIFF
--- a/frontend/src/components/ChatPanel.css
+++ b/frontend/src/components/ChatPanel.css
@@ -1,6 +1,7 @@
 .chat-panel {
   display: flex;
   flex-direction: column;
+  background-color: white;
   border-radius: 12px;
   transition: height 0.5s cubic-bezier(0.25, 0.1, 0.25, 1), 
               min-height 0.3s ease,
@@ -1059,7 +1060,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: transparent;
+  background-color: white;
   overflow: hidden;
   max-width: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- Fixed transparent background issue in chat panel containers
- Added white background to both regular and fullscreen chat panels
- Ensures chat messages are visible with proper background

## Test plan
- [x] Verified chat panel background is white in regular mode
- [x] Verified chat panel background is white in fullscreen mode
- [x] Verified questionnaire mode maintains proper styling

🤖 Generated with [Claude Code](https://claude.ai/code)